### PR TITLE
Update install-configure-cleint.md

### DIFF
--- a/doc_source/install-configure-client.md
+++ b/doc_source/install-configure-client.md
@@ -52,7 +52,7 @@ If you plan to download and install the client for your users, first download th
 
 To install and configure the AppStream 2\.0 client for your users, download the installation files\.
 
-1. Download the Enterprise Deployment Tool from [AppStream 2\.0 supported clients\.](https://clients.amazonappstream.com)
+1. Download the Enterprise Deployment Tool from [AppStream 2\.0 Enterprise Deployment Tool\.](https://clients.amazonappstream.com/installers/windows/AmazonAppStreamClient_EnterpriseSetup_1.0.320.zip)
 
 1. Navigate to the location where you downloaded the tool, right\-click the **AmazonAppStreamClient\_EnterpriseSetup\_<version>** folder, and choose **Extract All**\. The folder contains the following two installation programs:
    + AmazonAppStreamClientSetup\_<version>\.msi
@@ -66,11 +66,11 @@ After you download the AppStream 2\.0 client installation files, run the followi
 To run this script, you must be logged into the applicable computer with the local **Administrator** account\. You can also run the script remotely under the **System** account on startup\.
 
 ```
-Start-Process msiexec.exe -Wait -ArgumentList '/i 
-AmazonAppStreamClientSetup_<version>.msi /quiet'
+$ArgumentList = '/i AmazonAppStreamClientSetup_<version>.msi /quiet'
+Start-Process msiexec.exe -Wait -ArgumentList $ArgumentList
 
-Start-Process AmazonAppStreamUsbDriverSetup_<version>.exe -Wait -ArgumentList
-'/quiet'
+Start-Process AmazonAppStreamUsbDriverSetup_<version>.exe ` 
+-Wait -ArgumentList '/quiet'
 ```
 
 ## Configure the AppStream 2\.0 Client for Your Users<a name="configure-client"></a>


### PR DESCRIPTION
*Issue #, if available:*
1. The link to the Enterprise Deployment tool is hard to find.

*Description of changes:*\

1. Propose adding the link directly to the Enterprise Deployment Tool on line 55 as it currently takes customers to a landing page. Once arriving on said landing page, there is a small link to the tool that is not easily visible and one can misinterpret the link of the normal windows client as the Enterprise Tool. 

2. The second proposed change is not to address an issue but for convenience and ease of use. 
Currently the copy code button on line 69 is not working as expected when pasting the code into PowerShell. Not sure if this was done by design.

I am proposing adding a variable $ArgumentList on line 69 which can reduce the space used on webpage\screen and allow the copy code button to work in PowerShell as expected. (Alternatively one could solve this with a back tick before the word -ArgumentList i.e 

```
Start-Process msiexec.exe -Wait `
-ArgumentList '/i AmazonAppStreamClientSetup_<version>.exe /quiet'
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
